### PR TITLE
Adjusting Team Panels Layout

### DIFF
--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -12,8 +12,8 @@ const TeamPage = () => {
         {/* Creator Group */}
         <div className="creatorGroup p-3 pb-4 m-4" id="2024">
           <h2 className="chapterTitle py-1">Chapter 2024</h2>
-          <div className='container'>
-            <div className='row justify-content-md-center'>
+          <div className='container-fluid'>
+            <div className='row'>
               <Card />
             </div>
           </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,13 +5,13 @@ import Link from 'next/link';
 export default async function Page()
 {
   return (
-    <div>
+    <div className="d-flex flex-wrap justify-content-center ">
       {Cards.cards.map(person =>
-        {return <div className={`panel ${person.year}`} key={person.name}>
+        {return <div className={`card border-black border-3 m-1 ${person.year}`} key={person.name}>
           <Link href={person.linkedin}>
-            <h2 id={person.name}>{person.name}</h2>
+            <div className="card-header bg-transparent" id={person.name}>{person.name}</div>
             <Image width={200} height={200} src={person.img} className="img-fluid" alt=""></Image>
-            <h2 className={person.role}>{person.role}</h2>
+            <div className={`card-footer bg-transparent${person.role}`}>{person.role}</div>
           </Link>
           </div>}
       )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -343,6 +343,24 @@ main{
     transform: translate(-50%, -50%);
 }
 
+.card
+{
+    width: 300px;
+    height: 310px;
+}
+
+a
+{
+    color: black;
+    text-decoration: none;
+}
+
+.card-header, .card-footer
+{
+    font-size: 1.5rem;
+}
+
+
 /* X-Small devices (portrait phones, less than 576px)
 No media query for `xs` since this is the default in Bootstrap */
 


### PR DESCRIPTION
### Used flexbox to automatically adjust the positioning of the team panels on the team page.

_**Hover animation is not in place yet, but the panels are clickable and can be changed by editing `Card.tsx`**_