### PR TITLE
quick navbar adjustments

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -11,23 +11,26 @@ const NavBar = () => {
         <button className="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-controls="offcanvasNavbar" aria-label="Toggle navigation">
           <Image src="../images/BurgerMenu.svg" alt="Crowd Comic Favicon" width={78} height={46} />
         </button>
-        <div className="offcanvas offcanvas-end" tabIndex={-1} id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
+        <div className="offcanvas offcanvas-end w-50" tabIndex={-1} id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
           <div className="offcanvas-header">
             <h5 className="offcanvas-header" id="offcanvasNavbarLabel">Crowd Comic</h5>
             <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
           </div>
           <div className="offcanvas-body">
-            <ul className="navbar-nav justify-content-end flex-grow-1 pe-3">
-              <li className="nav-item">
+            <ul className="navbar-nav justify-content-end flex-grow-1">
+              <li className="nav-item ps-4">
                 <Link className="nav-link active" id="homeLink" aria-current="page" href="./">Home</Link>
               </li>
-              <li className="nav-item">
+              <li className="nav-item ps-4">
                 <Link className="nav-link" id="teamLink" href="../team">Team</Link>
               </li>
-              <li className="nav-item">
-                <Link className="nav-link" id="comicLink" href="">Comic</Link>
+              <li className="nav-item ps-4">
+                <Link className="nav-link" id="comicLink" href="">Read</Link>
               </li>
-              <li className="nav-item">
+              <li className="nav-item ps-4">
+                <Link className="nav-link" id="comicLink" href="">Create</Link>
+              </li>
+              <li className="nav-item ps-3 pt-3">
                 <button className="btn btn-outline-dark">Login</button>
               </li>
             </ul>


### PR DESCRIPTION
changed the navbar to only cover 50% of the screen and used padding to move the navbar body elements so that the lined up vertically a bit better.

All of the changes were done using bootstrap classes so if they need adjustments it will be fairly easy however, some further css could potentially be helpful when we have more content