### PR TITLE
Simple Export Canvas To PNG

### DIFF
--- a/src/app/comic/create/page.tsx
+++ b/src/app/comic/create/page.tsx
@@ -3,12 +3,22 @@ import CreateToolsCanvas from '../../../components/CreateToolsCanvas';
 import Link from 'next/link';
 import '../../../styles/createPage.css';
 
+const exportToPNG = () => {
+    // const canvas = document.getElementById('canvas')
+    // const img = canvas.toDataURL('image/png')
+    var canvas = document.getElementById("canvas");
+    var dataURL = canvas.toDataURL("image/png");
+    var newTab = window.open('about:blank', 'image from canvas');
+    newTab.document.write("<img src='" + dataURL + "' alt='from canvas'/>");
+}
+
 const Create = () => {
     return (
-    <>
-        <CreateToolsCanvas/>
-        <Link href="/comic/create/publish">Continue</Link>
-    </>
+        <>
+            <CreateToolsCanvas />
+            <button onClick={exportToPNG}>Export To PNG</button>
+            <Link href="/comic/create/publish">Continue</Link>
+        </>
     );
 }
 

--- a/src/app/comic/create/page.tsx
+++ b/src/app/comic/create/page.tsx
@@ -4,19 +4,22 @@ import Link from 'next/link';
 import '../../../styles/createPage.css';
 
 const exportToPNG = () => {
-    // const canvas = document.getElementById('canvas')
-    // const img = canvas.toDataURL('image/png')
-    var canvas = document.getElementById("canvas");
-    var dataURL = canvas.toDataURL("image/png");
-    var newTab = window.open('about:blank', 'image from canvas');
-    newTab.document.write("<img src='" + dataURL + "' alt='from canvas'/>");
+    //converts html canvas to png
+    const canvas = document.getElementById("canvas");
+    const imgURL = canvas.toDataURL("image/png");
+
+    //sets up downloading
+    let downloadLink = document.createElement('a');
+    downloadLink.download = 'canvas_image.png';
+    downloadLink.href = imgURL;
+    downloadLink.click();
 }
 
 const Create = () => {
     return (
         <>
             <CreateToolsCanvas />
-            <button onClick={exportToPNG}>Export To PNG</button>
+            <button id='export-btn' onClick={exportToPNG}>Export To PNG</button>
             <Link href="/comic/create/publish">Continue</Link>
         </>
     );

--- a/src/components/CreateToolsCanvas.tsx
+++ b/src/components/CreateToolsCanvas.tsx
@@ -29,6 +29,10 @@ const CreateToolsCanvas = () =>
             return;
         }
 
+        //sets background to white
+        context.fillStyle = "#ffffff";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+
         // Set default values for context here
         context.strokeStyle = "black";
         context.lineWidth = 5;
@@ -144,6 +148,7 @@ const CreateToolsCanvas = () =>
             // Reset the source in case it is switching from the eraser tool
             contextReference.current.globalCompositeOperation="source-over";
             // Fill the canvas
+            contextReference.current.fillStyle = "#000000";
             contextReference.current?.fillRect(0, 0, canvasReference.current?.width, canvasReference.current?.height);
         }
     }
@@ -152,6 +157,8 @@ const CreateToolsCanvas = () =>
     function clearCanvas()
     {
         contextReference.current?.clearRect(0, 0, canvasReference.current?.width, canvasReference.current?.height);
+        contextReference.current.fillStyle = "#ffffff";
+        contextReference.current?.fillRect(0, 0, canvasReference.current?.width, canvasReference.current?.height);
     }
 
     // Undoes the last stroke to the canvas

--- a/src/components/CreateToolsCanvas.tsx
+++ b/src/components/CreateToolsCanvas.tsx
@@ -29,10 +29,6 @@ const CreateToolsCanvas = () =>
             return;
         }
 
-        //sets background to white
-        context.fillStyle = "#ffffff";
-        context.fillRect(0, 0, canvas.width, canvas.height);
-
         // Set default values for context here
         context.strokeStyle = "black";
         context.lineWidth = 5;
@@ -148,7 +144,6 @@ const CreateToolsCanvas = () =>
             // Reset the source in case it is switching from the eraser tool
             contextReference.current.globalCompositeOperation="source-over";
             // Fill the canvas
-            contextReference.current.fillStyle = "#000000";
             contextReference.current?.fillRect(0, 0, canvasReference.current?.width, canvasReference.current?.height);
         }
     }
@@ -157,8 +152,6 @@ const CreateToolsCanvas = () =>
     function clearCanvas()
     {
         contextReference.current?.clearRect(0, 0, canvasReference.current?.width, canvasReference.current?.height);
-        contextReference.current.fillStyle = "#ffffff";
-        contextReference.current?.fillRect(0, 0, canvasReference.current?.width, canvasReference.current?.height);
     }
 
     // Undoes the last stroke to the canvas


### PR DESCRIPTION
Added an export to PNG button which currently downloads the canvas as a png (with a transparent background) when clicked. 