### PR TITLE
Nick create tools

### DIFF
--- a/src/components/CreateToolsCanvas.tsx
+++ b/src/components/CreateToolsCanvas.tsx
@@ -3,6 +3,7 @@ import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import { ChangeEvent, MouseEvent, TouchEvent } from 'react';
 import EraserOptions from './EraserOptions';
 import PenOptions from './PenOptions';
+import FillOptions from './FillOptions';
 
 // This component will create the Canvas HTML Element as well as the user tools and associated functionality used to edit the canvas
 const CreateToolsCanvas = () =>
@@ -47,12 +48,14 @@ const CreateToolsCanvas = () =>
     // Boolean used to determine if the user is still drawing (holding their mouse or touch down on the canvas)
     const [isDrawing, setIsDrawing] = useState<boolean>(false);
 
+    // --- ERASER TOOL ---
     // Boolean used to determine if the eraser tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
     const [eraserOptionsEnabled, setEraserOptionsEnabled] = useState<boolean>(false);
 
     // Integer used to specify the size of the eraser brush.  This is modified in the EraserOptions component
     const [eraserSize, setEraserSize] = useState<number>(10);
 
+    /// --- PEN TOOL ---
     // Boolean used to determine if the pen tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
     const [penOptionsEnabled, setPenOptionsEnabled] = useState<boolean>(true);
 
@@ -61,6 +64,13 @@ const CreateToolsCanvas = () =>
 
     // String used to specify the color of the pen brush.  This is modified in the PenOptions component
     const [penColor, setPenColor] = useState<string>("black");
+
+    // --- FILL TOOL ---
+    // Boolean used to determine if the fill tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
+    const [fillOptionsEnabled, setFillOptionsEnabled] = useState<boolean>(false);
+
+    // String used to specify the color of the fill tool.  This is modified in the FillOptions component
+    const [fillColor, setFillColor] = useState<string>("black");
     
 
     // Custom hook as there are two parts to the edit history: the history of changes as well as the index of what is currently on screen
@@ -98,11 +108,19 @@ const CreateToolsCanvas = () =>
         {
             setPenOptionsEnabled(true);
             setEraserOptionsEnabled(false);
+            setFillOptionsEnabled(false);
         }
         else if(buttonSelected?.value == toolStates.ERASER)
         {
             setPenOptionsEnabled(false);
             setEraserOptionsEnabled(true);
+            setFillOptionsEnabled(false);
+        }
+        else if(buttonSelected?.value == toolStates.FILL)
+        {
+            setPenOptionsEnabled(false);
+            setEraserOptionsEnabled(false);
+            setFillOptionsEnabled(true);
         }
         
     }
@@ -189,6 +207,7 @@ const CreateToolsCanvas = () =>
         if(toolSelected == toolStates.FILL)
         {
             // Fill the canvas
+            contextReference.current.fillStyle = fillColor;
             contextReference.current?.fillRect(0, 0, canvasReference.current?.width, canvasReference.current?.height);
         }
     }
@@ -285,6 +304,7 @@ const CreateToolsCanvas = () =>
             <div id="toolOptions">
                 <PenOptions enabled={penOptionsEnabled} penSize={penSize} changePenSize={setPenSize} changePenColor={setPenColor}/>
                 <EraserOptions enabled={eraserOptionsEnabled} eraserSize={eraserSize} changeEraserSize={setEraserSize}/>
+                <FillOptions enabled={fillOptionsEnabled} changeFillColor={setFillColor}/>
             </div>
         </div>
     )

--- a/src/components/CreateToolsCanvas.tsx
+++ b/src/components/CreateToolsCanvas.tsx
@@ -35,8 +35,6 @@ const CreateToolsCanvas = () =>
         }
 
         // Set default values for context here
-        context.strokeStyle = "black";
-        context.lineWidth = 5;
         context.lineCap = "round";
         context.lineJoin = "round";
 
@@ -45,17 +43,24 @@ const CreateToolsCanvas = () =>
     }, [])
 
     // State Variables:
+    // --- DRAWING STATE ---
     // Boolean used to determine if the user is still drawing (holding their mouse or touch down on the canvas)
     const [isDrawing, setIsDrawing] = useState<boolean>(false);
 
-    // --- ERASER TOOL ---
-    // Boolean used to determine if the eraser tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
-    const [eraserOptionsEnabled, setEraserOptionsEnabled] = useState<boolean>(false);
+    // --- TOOLS ---
+    // Create an enum with all of the different possible tool states
+    const toolStates = Object.freeze({
+        PEN: 0,
+        ERASER: 1,
+        FILL: 2,
+        SHAPE: 3, 
+        TEXT: 4,
+        STICKER: 5
+    });
+    // Holds a reference the currently selected tool 
+    const [toolSelected, setToolSelected] = useState(0);
 
-    // Integer used to specify the size of the eraser brush.  This is modified in the EraserOptions component
-    const [eraserSize, setEraserSize] = useState<number>(10);
-
-    /// --- PEN TOOL ---
+    // --- PEN TOOL ---
     // Boolean used to determine if the pen tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
     const [penOptionsEnabled, setPenOptionsEnabled] = useState<boolean>(true);
 
@@ -64,6 +69,13 @@ const CreateToolsCanvas = () =>
 
     // String used to specify the color of the pen brush.  This is modified in the PenOptions component
     const [penColor, setPenColor] = useState<string>("black");
+
+    // --- ERASER TOOL ---
+    // Boolean used to determine if the eraser tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
+    const [eraserOptionsEnabled, setEraserOptionsEnabled] = useState<boolean>(false);
+
+    // Integer used to specify the size of the eraser brush.  This is modified in the EraserOptions component
+    const [eraserSize, setEraserSize] = useState<number>(10);
 
     // --- FILL TOOL ---
     // Boolean used to determine if the fill tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
@@ -84,17 +96,7 @@ const CreateToolsCanvas = () =>
     const [editHistory, setEditHistory] = useState([]);
     const [historyIndex, setHistoryIndex] = useState(-1);*/
 
-    // Create an enum with all of the different possible tool states
-    const toolStates = Object.freeze({
-        PEN: 0,
-        ERASER: 1,
-        FILL: 2,
-        SHAPE: 3, 
-        TEXT: 4,
-        STICKER: 5
-    });
-    // Holds a reference the currently selected tool 
-    const [toolSelected, setToolSelected] = useState(0);
+
 
     // *** FUNCTIONS ***
 

--- a/src/components/CreateToolsCanvas.tsx
+++ b/src/components/CreateToolsCanvas.tsx
@@ -2,6 +2,7 @@
 import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import { ChangeEvent, MouseEvent, TouchEvent } from 'react';
 import EraserOptions from './EraserOptions';
+import PenOptions from './PenOptions';
 
 // This component will create the Canvas HTML Element as well as the user tools and associated functionality used to edit the canvas
 const CreateToolsCanvas = () =>
@@ -52,6 +53,16 @@ const CreateToolsCanvas = () =>
     // Integer used to specify the size of the eraser brush.  This is modified in the EraserOptions component
     const [eraserSize, setEraserSize] = useState<number>(10);
 
+    // Boolean used to determine if the pen tools section is displayed and interactible.  This will be changed in the radioButtons onChange event
+    const [penOptionsEnabled, setPenOptionsEnabled] = useState<boolean>(true);
+
+    // Integer used to specify the size of the pen brush.  This is modified in the PenOptions component
+    const [penSize, setPenSize] = useState<number>(10);
+
+    // String used to specify the color of the pen brush.  This is modified in the PenOptions component
+    const [penColor, setPenColor] = useState<string>("black");
+    
+
     // Custom hook as there are two parts to the edit history: the history of changes as well as the index of what is currently on screen
     /*const useHistory = (initialState) => {
         const [history, setHistory] = useState(initialState);
@@ -85,10 +96,12 @@ const CreateToolsCanvas = () =>
 
         if(buttonSelected?.value == toolStates.PEN)
         {
+            setPenOptionsEnabled(true);
             setEraserOptionsEnabled(false);
         }
         else if(buttonSelected?.value == toolStates.ERASER)
         {
+            setPenOptionsEnabled(false);
             setEraserOptionsEnabled(true);
         }
         
@@ -127,6 +140,8 @@ const CreateToolsCanvas = () =>
             if(toolSelected == toolStates.PEN)
             {
                 contextReference.current.globalCompositeOperation="source-over";
+                contextReference.current.lineWidth = penSize;
+                contextReference.current.strokeStyle = penColor;
             }
             else if(toolSelected == toolStates.ERASER)
             {
@@ -268,6 +283,7 @@ const CreateToolsCanvas = () =>
             />
 
             <div id="toolOptions">
+                <PenOptions enabled={penOptionsEnabled} penSize={penSize} changePenSize={setPenSize} changePenColor={setPenColor}/>
                 <EraserOptions enabled={eraserOptionsEnabled} eraserSize={eraserSize} changeEraserSize={setEraserSize}/>
             </div>
         </div>

--- a/src/components/CreateToolsCanvas.tsx
+++ b/src/components/CreateToolsCanvas.tsx
@@ -124,7 +124,6 @@ const CreateToolsCanvas = () =>
             setEraserOptionsEnabled(false);
             setFillOptionsEnabled(true);
         }
-        
     }
 
     // Begins the process of drawing the user's input to the canvas HTMLElement

--- a/src/components/EraserOptions.tsx
+++ b/src/components/EraserOptions.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 // *** Eraser Options is used in order to changed the different values associated with the eraser tool in CreateToolsCanvas ***
 const EraserOptions = ({enabled, eraserSize, changeEraserSize}) =>
 {

--- a/src/components/EraserOptions.tsx
+++ b/src/components/EraserOptions.tsx
@@ -14,7 +14,7 @@ const EraserOptions = ({enabled, eraserSize, changeEraserSize}) =>
     if(enabled)
     {
         return(
-            <div>
+            <div id="eraserTools">
                 <h3>Eraser Tools</h3>
                 <div id="eraserSlider">
                     <label id="sliderLabel" htmlFor="eraserRange">Eraser Size: {eraserSize}</label>

--- a/src/components/EraserOptions.tsx
+++ b/src/components/EraserOptions.tsx
@@ -1,0 +1,33 @@
+import { useState, useRef } from "react";
+// *** Eraser Options is used in order to changed the different values associated with the eraser tool in CreateToolsCanvas ***
+const EraserOptions = ({enabled, eraserSize, changeEraserSize}) =>
+{
+    const sliderReference = useRef<HTMLInputElement>(null);
+
+    // Whenever the slider is adjusted, change the value of eraserSize.  This will update the label text as well as the value in the parent CreateCanvasTools component
+    function updateSize()
+    {
+        changeEraserSize(parseInt(sliderReference.current.value));
+    }
+
+    // If the component is set to be enabled, return HTML, otherwise, return nothing
+    if(enabled)
+    {
+        return(
+            <div>
+                <h3>Eraser Tools</h3>
+                <div id="eraserSlider">
+                    <label id="sliderLabel" htmlFor="eraserRange">Eraser Size: {eraserSize}</label>
+                    <input type="range" min="1" max="20" defaultValue={eraserSize} step="1" id="eraserRange" ref={sliderReference} onChange={updateSize}></input>
+                </div>
+            </div>
+        )
+    }
+    else
+    {
+        return(null)
+    }
+
+}
+
+export default EraserOptions

--- a/src/components/FillOptions.tsx
+++ b/src/components/FillOptions.tsx
@@ -14,6 +14,7 @@ const FillOptions = ({enabled, changeFillColor}) =>
     {
         return(
             <div id="fillTools">
+                <h3>Fill Tools</h3>
                 <div id="paletteButtons">
                     <button onClick={() => changeFillColor(color1)}></button>
                     <button onClick={() => changeFillColor(color2)}></button>

--- a/src/components/FillOptions.tsx
+++ b/src/components/FillOptions.tsx
@@ -1,0 +1,34 @@
+import { useRef } from "react";
+
+// *** Fill Options is used in order to changed the different values associated with the fill tool in CreateToolsCanvas ***
+const FillOptions = ({enabled, changeFillColor}) =>
+{
+    const color1 = "rgb(255, 255, 255)";
+    const color2 = "rgb(192, 192, 192)";
+    const color3 = "rgb(128, 128, 128)";
+    const color4 = "rgb(64, 64, 64)";
+    const color5 = "rgb(0, 0, 0)";
+
+    // If the component is set to be enabled, return HTML, otherwise, return nothing
+    if(enabled)
+    {
+        return(
+            <div id="fillTools">
+                <div id="paletteButtons">
+                    <button onClick={() => changeFillColor(color1)}></button>
+                    <button onClick={() => changeFillColor(color2)}></button>
+                    <button onClick={() => changeFillColor(color3)}></button>
+                    <button onClick={() => changeFillColor(color4)}></button>
+                    <button onClick={() => changeFillColor(color5)}></button>
+                </div>
+            </div>
+        )
+    }
+    else
+    {
+        return(null)
+    }
+
+}
+
+export default FillOptions

--- a/src/components/PenOptions.tsx
+++ b/src/components/PenOptions.tsx
@@ -1,0 +1,46 @@
+import { useRef } from "react";
+
+// *** Pen Options is used in order to changed the different values associated with the pen tool in CreateToolsCanvas ***
+const PenOptions = ({enabled, penSize, changePenSize, changePenColor}) =>
+{
+    const sliderReference = useRef<HTMLInputElement>(null);
+    const color1 = "rgb(255, 255, 255)";
+    const color2 = "rgb(192, 192, 192)";
+    const color3 = "rgb(128, 128, 128)";
+    const color4 = "rgb(64, 64, 64)";
+    const color5 = "rgb(0, 0, 0)";
+
+    // Whenever the slider is adjusted, change the value of penSize.  This will update the label text as well as the value in the parent CreateCanvasTools component
+    function updateSize()
+    {
+        changePenSize(parseInt(sliderReference.current.value));
+    }
+
+    // If the component is set to be enabled, return HTML, otherwise, return nothing
+    if(enabled)
+    {
+        return(
+            <div>
+                <h3>Pen Tools</h3>
+                <div id="penSlider">
+                    <label id="sliderLabel" htmlFor="penRange">Pen Size: {penSize}</label>
+                    <input type="range" min="1" max="20" defaultValue={penSize} step="1" id="penRange" ref={sliderReference} onChange={updateSize}></input>
+                </div>
+                <div id="paletteButtons">
+                    <button onClick={() => changePenColor(color1)}></button>
+                    <button onClick={() => changePenColor(color2)}></button>
+                    <button onClick={() => changePenColor(color3)}></button>
+                    <button onClick={() => changePenColor(color4)}></button>
+                    <button onClick={() => changePenColor(color5)}></button>
+                </div>
+            </div>
+        )
+    }
+    else
+    {
+        return(null)
+    }
+
+}
+
+export default PenOptions

--- a/src/components/PenOptions.tsx
+++ b/src/components/PenOptions.tsx
@@ -20,7 +20,7 @@ const PenOptions = ({enabled, penSize, changePenSize, changePenColor}) =>
     if(enabled)
     {
         return(
-            <div>
+            <div id="penTools">
                 <h3>Pen Tools</h3>
                 <div id="penSlider">
                     <label id="sliderLabel" htmlFor="penRange">Pen Size: {penSize}</label>

--- a/src/styles/createPage.css
+++ b/src/styles/createPage.css
@@ -27,3 +27,7 @@ canvas
 {
     order: 1;
 }
+#toolOptions
+{
+    order: 2;
+}


### PR DESCRIPTION
**Created Options for Pen, Eraser, and Fill Tool**
These three tools now have options that the user can use to modify how the tool works.  This is customized on the right side of the canvas.

Pen:
- Brush Size
- Brush Color

Eraser: 
- Brush Size

Fill:
- Fill Color

The options HTML is created using components for each individual options menu that is dynamically placed onto the page whenever they are enabled or disabled.  This is done in the toolRadioSelects onChange() event: findSelected().  Whenever a new tool is selected, its corresponding options menu is enabled.  The user's selections are also saved so they are able to change menus and have their selections remain the same