### PR TITLE
Transform Tool: Moving

### DIFF
--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -510,7 +510,6 @@ const CreateToolsCanvasPaperJS = () => {
     const [isTranforming, setIsTransforming] = useState(false);
 
     // Array of Information needed for transform
-    //could get rid of and just use selection info?
     const [transformInfo, setTransformInfo] = useState([] as paper.Path.Rectangle[])
 
     // String describing action user is doing (moving, resizing, rotating, etc.)
@@ -531,6 +530,7 @@ const CreateToolsCanvasPaperJS = () => {
         }
     }
 
+    //erases selected area
     function clearAreaSelected(selection: paper.Path.Rectangle) {
         let eraserSelection = selection;
         eraserSelection.fillColor = new paper.Color("black");

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -535,7 +535,6 @@ const CreateToolsCanvasPaperJS = () => {
             setRasterInfo(existingItems => {
                 //return existingItems.slice(0, existingItems.length - 1)
                 return existingItems.filter((item, i) => i !== existingItems.length - 1);
-                setIsTransforming(false);
             })
         }
     }
@@ -576,11 +575,15 @@ Destination-out: Existing content is kept where it does not overlap with the new
                 setTransformInfo([tempTransformAreaBounds]);
                 let tempTransformSelectedArea = rasterInfo[0].getSubRaster(selectionInfo[1]);
                 setRasterInfo(prevState => [...prevState, tempTransformSelectedArea]);
+                //remove raster from active layer
 
                 clearAreaSelected(tempTransformAreaBounds);
 
+                //readd raster to active layer
+
                 //for first time transforming only
                 if (tempTransformAreaBounds.contains(event.point)) {
+                    console.log("runs")
                     setTransformAction("moving");
                     return;
                 }

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -529,18 +529,25 @@ const CreateToolsCanvasPaperJS = () => {
 
     // Checks if previously was transforming and resets states
     function clearSelection(){
-        if (isTranforming) {
+        if (isTranforming && rasterInfo.length == 2) {
+            console.log("runs")
             rasterInfo[1].selected = false;
-        }
+            setRasterInfo(existingItems => {
+                //return existingItems.slice(0, existingItems.length - 1)
+                return existingItems.filter((item, i) => i !== existingItems.length - 1);
+            setIsTransforming(false);
+        })
     }
+}
 
     transformTool.onMouseDown = function (event: paper.ToolEvent) {
         if (areaSelected && canvasProject.activeLayer.locked == false) {
             //sets up needed variables for raster moving on first time transforming
-            if (!isTranforming) {
+            if (!isTranforming && areaSelected) {
                 let tempTransformAreaBounds = new paper.Path.Rectangle(selectionInfo[0]);
                 setTransformInfo([tempTransformAreaBounds]);
                 let tempTransformSelectedArea = rasterInfo[0].getSubRaster(selectionInfo[1]);
+                
                 setRasterInfo(prevState => [...prevState, tempTransformSelectedArea]);
 
                 //for first time transforming only
@@ -625,6 +632,7 @@ const CreateToolsCanvasPaperJS = () => {
             setShapeOptionsEnabled(false);
             setStickerOptionsEnabled(false);
             clearSelection();
+            setAreaSelected(false);
         }
         else if (Number(buttonSelected?.value) == toolStates.ERASER) {
             eraserTool.activate();
@@ -634,6 +642,7 @@ const CreateToolsCanvasPaperJS = () => {
             setShapeOptionsEnabled(false);
             setStickerOptionsEnabled(false);
             clearSelection();
+            setAreaSelected(false);
         }
         else if (Number(buttonSelected?.value) == toolStates.FILL) {
             fillTool.activate();
@@ -643,6 +652,7 @@ const CreateToolsCanvasPaperJS = () => {
             setShapeOptionsEnabled(false);
             setStickerOptionsEnabled(false);
             clearSelection();
+            setAreaSelected(false);
         }
         else if (Number(buttonSelected?.value) == toolStates.SHAPE) {
             shapeTool.activate();
@@ -652,6 +662,7 @@ const CreateToolsCanvasPaperJS = () => {
             setShapeOptionsEnabled(true);
             setStickerOptionsEnabled(false);
             clearSelection();
+            setAreaSelected(false);
         }
         else if (Number(buttonSelected?.value) == toolStates.STICKER) {
             stickerTool.activate();
@@ -661,6 +672,7 @@ const CreateToolsCanvasPaperJS = () => {
             setShapeOptionsEnabled(false);
             setStickerOptionsEnabled(true);
             clearSelection();
+            setAreaSelected(false);
         }
         //rasterize active canvas layer when clicked and set const as it 
         else if (Number(buttonSelected?.value) == toolStates.SELECT) {

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -422,18 +422,9 @@ const CreateToolsCanvasPaperJS = () => {
     }
 
     // --- SELECT TOOL ---
-    // String describing action user is doing (moving, resizing, rotating, etc.)
-    const [selectAction, setSelectAction] = useState("none");
-
     // Points describing the selected area's dimensions (start and end)
     const [startSelectPoint, setStartSelectPoint] = useState(new paper.Point(0, 0))
     const [endSelectPoint, setEndSelectPoint] = useState(new paper.Point(0, 0))
-
-    // Bounds of selected area of canvas
-    let shownSelectedAreaBounds: paper.Path;
-
-    // Selected area of rasterized canvas
-    let selectedArea: paper.Raster;
 
     //Selection info to be passed on to transform tool (shown bounds + selected area)
     const [selectionInfo, setSelectionInfo] = useState([] as paper.Rectangle[]);
@@ -519,6 +510,7 @@ const CreateToolsCanvasPaperJS = () => {
     const [isTranforming, setIsTransforming] = useState(false);
 
     // Array of Information needed for transform
+    //could get rid of and just use selection info?
     const [transformInfo, setTransformInfo] = useState([] as paper.Path.Rectangle[])
 
     // String describing action user is doing (moving, resizing, rotating, etc.)
@@ -530,8 +522,8 @@ const CreateToolsCanvasPaperJS = () => {
     // Checks if previously was transforming and resets states
     function clearSelection() {
         if (isTranforming && rasterInfo.length == 2) {
-            console.log("runs")
             rasterInfo[1].selected = false;
+            //if another area is not selected, then get rid of previous raster/selected area from array
             setRasterInfo(existingItems => {
                 //return existingItems.slice(0, existingItems.length - 1)
                 return existingItems.filter((item, i) => i !== existingItems.length - 1);
@@ -570,14 +562,14 @@ Destination-out: Existing content is kept where it does not overlap with the new
     transformTool.onMouseDown = function (event: paper.ToolEvent) {
         if (areaSelected && canvasProject.activeLayer.locked == false) {
             //sets up needed variables for raster moving on first time transforming
-            if (!isTranforming && areaSelected) {
+            if (!isTranforming) {
                 //add original vars separate from temp???
                 let tempTransformAreaBounds = new paper.Path.Rectangle(selectionInfo[0]);
                 setTransformInfo([tempTransformAreaBounds]);
 
                 //remove raster from active layer
                 //tempTransformSelectedArea.remove();
-                clearAreaSelected(tempTransformAreaBounds);
+                //clearAreaSelected(tempTransformAreaBounds);
 
                 let tempTransformSelectedArea = rasterInfo[0].getSubRaster(selectionInfo[1]);
                 setRasterInfo(prevState => [...prevState, tempTransformSelectedArea]);
@@ -705,6 +697,7 @@ Destination-out: Existing content is kept where it does not overlap with the new
         //rasterize active canvas layer when clicked and set const as it 
         else if (Number(buttonSelected?.value) == toolStates.SELECT) {
             //rasterizes layer when select tool is first selected
+            //should check if new area has been selected before running
             let raster = canvasProject.activeLayer.rasterize();
             clearSelection();
             setRasterInfo([raster]);
@@ -720,6 +713,7 @@ Destination-out: Existing content is kept where it does not overlap with the new
         else if (Number(buttonSelected?.value) == toolStates.TRANSFORM) {
             transformTool.activate();
             setIsTransforming(false);
+            //should check if new area has been selected before running
             setTransformInfo([]);
             clearSelection();
             setPenOptionsEnabled(false);
@@ -756,6 +750,7 @@ Destination-out: Existing content is kept where it does not overlap with the new
             //temp set until deselect option made
             setAreaSelected(false);
             setIsTransforming(false);
+            clearSelection();
         }
     }
 

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -515,10 +515,6 @@ const CreateToolsCanvasPaperJS = () => {
     // --- TRANSFORM TOOL ---
     // Neeeded informations is gotten through selection info and raster info arrays
 
-    // Bounds of selected area of canvas
-    let transformAreaBounds: paper.Path;
-    let transformSelectedArea: paper.Raster;
-
     // Checks if user has been transforming (is only false on first use of transform tool)
     const [isTranforming, setIsTransforming] = useState(false);
 
@@ -531,25 +527,24 @@ const CreateToolsCanvasPaperJS = () => {
     // The Transform Tool:
     const [transformTool, setTransformTool] = useState<paper.Tool>(new paper.Tool());
 
-    //checks if previously was transforming and resets states
+    // Checks if previously was transforming and resets states
     function clearSelection(){
         if (isTranforming) {
             rasterInfo[1].selected = false;
-            rasterInfo[1].remove();
         }
     }
 
     transformTool.onMouseDown = function (event: paper.ToolEvent) {
         if (areaSelected && canvasProject.activeLayer.locked == false) {
-            //sets up needed variables for raster moving
+            //sets up needed variables for raster moving on first time transforming
             if (!isTranforming) {
-                transformAreaBounds = new paper.Path.Rectangle(selectionInfo[0]);
-                setTransformInfo([transformAreaBounds]);
-                transformSelectedArea = rasterInfo[0].getSubRaster(selectionInfo[1]);
-                setRasterInfo(prevState => [...prevState, transformSelectedArea]);
+                let tempTransformAreaBounds = new paper.Path.Rectangle(selectionInfo[0]);
+                setTransformInfo([tempTransformAreaBounds]);
+                let tempTransformSelectedArea = rasterInfo[0].getSubRaster(selectionInfo[1]);
+                setRasterInfo(prevState => [...prevState, tempTransformSelectedArea]);
 
                 //for first time transforming only
-                if (transformAreaBounds.contains(event.point)) {
+                if (tempTransformAreaBounds.contains(event.point)) {
                     setTransformAction("moving");
                     return;
                 }
@@ -562,6 +557,8 @@ const CreateToolsCanvasPaperJS = () => {
             // }
             //runs if mouse hits area inside selection
             if (transformInfo[0].contains(event.point)) {
+                //needs to solve selection moving even  when transformed area is not clicked
+                //(solving this also requires solving issue with transforminfo not updating)
                 setTransformAction("moving");
                 return;
             }

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -564,8 +564,6 @@ const CreateToolsCanvasPaperJS = () => {
             // }
             //runs if mouse hits area inside selection
             if (transformInfo[0].contains(event.point)) {
-                //needs to solve selection moving even  when transformed area is not clicked
-                //(solving this also requires solving issue with transforminfo not updating)
                 setTransformAction("moving");
                 return;
             }
@@ -585,7 +583,7 @@ const CreateToolsCanvasPaperJS = () => {
             //changes position of selected area if moving
             if (transformAction == "moving") {
                 setIsTransforming(true);
-                //transformAreaBounds.position = event.point;
+                transformInfo[0].position = event.point;
                 rasterInfo[1].position = event.point;
                 rasterInfo[1].selected = true;
                 return;
@@ -617,6 +615,8 @@ const CreateToolsCanvasPaperJS = () => {
         }
     }
     transformTool.onMouseUp = function () {
+        //resets transform action
+        setTransformAction("none");
     }
 
     // *** FUNCTIONS ***

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -571,19 +571,19 @@ Destination-out: Existing content is kept where it does not overlap with the new
         if (areaSelected && canvasProject.activeLayer.locked == false) {
             //sets up needed variables for raster moving on first time transforming
             if (!isTranforming && areaSelected) {
+                //add original vars separate from temp???
                 let tempTransformAreaBounds = new paper.Path.Rectangle(selectionInfo[0]);
                 setTransformInfo([tempTransformAreaBounds]);
-                let tempTransformSelectedArea = rasterInfo[0].getSubRaster(selectionInfo[1]);
-                setRasterInfo(prevState => [...prevState, tempTransformSelectedArea]);
-                //remove raster from active layer
 
+                //remove raster from active layer
+                //tempTransformSelectedArea.remove();
                 clearAreaSelected(tempTransformAreaBounds);
 
-                //readd raster to active layer
+                let tempTransformSelectedArea = rasterInfo[0].getSubRaster(selectionInfo[1]);
+                setRasterInfo(prevState => [...prevState, tempTransformSelectedArea]);
 
                 //for first time transforming only
                 if (tempTransformAreaBounds.contains(event.point)) {
-                    console.log("runs")
                     setTransformAction("moving");
                     return;
                 }
@@ -608,6 +608,8 @@ Destination-out: Existing content is kept where it does not overlap with the new
             if (transformAction == "moving") {
                 setIsTransforming(true);
                 transformInfo[0].position = event.point;
+                
+                //not null but not showing
                 rasterInfo[1].position = event.point;
                 rasterInfo[1].selected = true;
                 return;
@@ -644,11 +646,6 @@ Destination-out: Existing content is kept where it does not overlap with the new
             setTransformAction("none");
         }
     }
-
-    useEffect(() => {
-    console.log("TRANSFORM BOUNDS: " + transformInfo[0]);
-    console.log("RASTER INFO: " + rasterInfo[1]);
-    }, [transformInfo, rasterInfo]);
 
     // *** FUNCTIONS ***
     // Find which radioButton is currently selected and update the state of the tool selected


### PR DESCRIPTION
Selection Tool

- Canvas is rasterized and set as first of rasterInfo array upon first activation
- Sets selection info array with bounds rect and selected area rect to be passed to the transform tool

Transform Tool (Moving Selected Area Position)

- Uses info passed by selectionInfo and rasterInfo array to set up movable selected area 
- Upon clicking inside the selection, user is able to move selected area position to where the user drags their mouse