### PR TITLE
Cookie session validation

### DIFF
--- a/src/api/apiCalls.ts
+++ b/src/api/apiCalls.ts
@@ -1,5 +1,6 @@
 const baseUrl = 'http://localhost:4000';
 import { CreatePanelSet } from "../components/interfaces";
+import { getSessionCookie } from "@/app/login/loginUtils";
 
 const getAPICall = async (url: string) => {
     return await fetch(`${baseUrl}${url}`, {
@@ -17,10 +18,12 @@ const getAPICall = async (url: string) => {
 };
 
 const postAPICall = async (url: string, body: object) => {
+    const sessionObj = await getSessionCookie();
+    const session = JSON.stringify(sessionObj);
     return await fetch(`${baseUrl}${url}`, {
         body: JSON.stringify(body),
         method: 'POST',
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json",  "Session-Cookie": `${session}` },
     }).then(response => {
         return response.json();
 
@@ -33,9 +36,12 @@ const postAPICall = async (url: string, body: object) => {
 }
 
 const postAPICallFormData = async (url: string, formData: FormData) => {
+    const sessionObj = await getSessionCookie();
+    const session = JSON.stringify(sessionObj);
     return await fetch(`${baseUrl}${url}`, {
-      method: 'POST',
       body: formData,
+      headers:{ "Session-Cookie": `${session}`},
+      method: 'POST',
     })
     .then(response =>{return response.json()})
     .then(json => {

--- a/src/api/apiCalls.ts
+++ b/src/api/apiCalls.ts
@@ -423,7 +423,7 @@ const fetchImage = async(imageUrl : string) =>{
     });
 }
 
-const publishHandler = async(panelSet : CreatePanelSet, currentUser : string) =>{
+const publishHandler = async(panelSet : CreatePanelSet) =>{
         //get the image files
         const image1 = await fetchImage(panelSet.panels[0].imgSrc) as File | Error;
         if(image1 instanceof Error) return new Error(`There was an error getting the 1st image: ${image1.message}`);
@@ -456,11 +456,10 @@ const publishHandler = async(panelSet : CreatePanelSet, currentUser : string) =>
         const parentHookID = panelSet.previous_hook?.id;
 
         //get the hook id
-        return await publish(image1, image2, image3,currentUser, hooks, parentHookID);
+        return await publish(image1, image2, image3, hooks, parentHookID);
 }
-const publish = async (image1 : File, image2 : File, image3 : File, authorId : string, hooks : Array<hook>, hookId : number | undefined) => {
+const publish = async (image1 : File, image2 : File, image3 : File, hooks : Array<hook>, hookId : number | undefined) => {
     const data = {
-        author_id: authorId,
         hook_id: hookId,
         hooks: hooks
     };

--- a/src/app/login/loginUtils.ts
+++ b/src/app/login/loginUtils.ts
@@ -113,4 +113,8 @@ const logout = async () => {
     cookies().set('session', '', { expires: new Date(0) });
 }
 
-export { authenticateSession, login, register, logout };
+const getSessionCookie = () =>{
+    return cookies().get('session');
+}
+
+export {authenticateSession, login, register, logout, getSessionCookie};

--- a/src/components/publish/BranchPage.tsx
+++ b/src/components/publish/BranchPage.tsx
@@ -58,6 +58,7 @@ const BranchPage = () => {
 
         authenticateSession().then((user) =>{
             console.log(user);
+            if(user.message) router.push(`/sign-in`);
         });
         
         // retrieve comic images from create page using local storage

--- a/src/components/publish/BranchPage.tsx
+++ b/src/components/publish/BranchPage.tsx
@@ -55,9 +55,11 @@ const BranchPage = () => {
     // one time setup
     useEffect(() => {
 
-        const getUser = async () => {
-            await authenticateSession();
-        }
+
+        authenticateSession().then((user) =>{
+            console.log(user);
+        });
+        
         // retrieve comic images from create page using local storage
         const storedImageLinks = [
             loadImageAndConvertToURL(localStorage.getItem('image-1')) || imageLinks[0],
@@ -67,7 +69,6 @@ const BranchPage = () => {
 
         setImageLinks(storedImageLinks);
 
-        getUser();
 
         panelSet.panels[0].imgSrc = storedImageLinks[0];
         panelSet.panels[1].imgSrc = storedImageLinks[1];

--- a/src/components/publish/BranchPage.tsx
+++ b/src/components/publish/BranchPage.tsx
@@ -17,7 +17,6 @@ const BranchPage = () => {
         author_id: '',
         panels: emptyPanelSet()
     });
-    const [currentUser, setUser] = useState('');
     const [activePanel, setActivePanel] = useState(0);
     const activePanelHooks = () => panelSet.panels[activePanel].hooks;
     const setActivePanelHooks = (hooks: CreateHook[], panelIndex: number) => {
@@ -57,9 +56,7 @@ const BranchPage = () => {
     useEffect(() => {
 
         const getUser = async () => {
-            const user = await authenticateSession();
-            if (user)
-                setUser(user.id);
+            await authenticateSession();
         }
         // retrieve comic images from create page using local storage
         const storedImageLinks = [
@@ -70,7 +67,7 @@ const BranchPage = () => {
 
         setImageLinks(storedImageLinks);
 
-        if (!currentUser) getUser();
+        getUser();
 
         panelSet.panels[0].imgSrc = storedImageLinks[0];
         panelSet.panels[1].imgSrc = storedImageLinks[1];

--- a/src/components/publish/BranchPage.tsx
+++ b/src/components/publish/BranchPage.tsx
@@ -134,16 +134,6 @@ const BranchPage = () => {
         setAddingHook(false);
     }
 
-    /*
-    NOTE - pushToLocalStorage will be replaced with a method to push all of the data to the database to be stored as a panel set. As it stands right 
-    now there is no user set up which may cause issue with the data upload. Will need to provide some kind of guest or default user for database uploads 
-    so that the database can work as intended.
-    */
-    //packages ps and then pushes it to local storage
-    // const pushToLocalStorage = () => { }
-
-
-
     return (<>
         <main className={`${styles.body}`}>
             <div id={styles.publishContainer}>
@@ -179,7 +169,7 @@ const BranchPage = () => {
                     confirmBranchHook={() => confirmBranchHook(activePanel)}
                     removeBranchHook={removeBranchHook}
                     publish={async () => {
-                        const response = await publishHandler(panelSet, currentUser);
+                        const response = await publishHandler(panelSet);
                         console.log(response);
 
                         if (response instanceof Error) {


### PR DESCRIPTION
# Description
-Sends cookie data to POST requests on the backend, which validates the cookie and rejects the request if the user is not signed in. Test with the backend `cookies-for-the-session` branch pr. 
- Both POST and POST form data methods in `apicalls` were changed
- Helper added to `loginUtils` to get the cookie
- Publish no longer grabs user from page and sends it, as the cookie has access to the user.