### PR TITLE
Hook id integration

### DIFF
--- a/src/api/apiCalls.ts
+++ b/src/api/apiCalls.ts
@@ -469,7 +469,7 @@ const publishHandler = async(panelSet : CreatePanelSet) =>{
         })
 
         //get the hookId
-        const parentHookID = panelSet.previous_hook?.id;
+        const parentHookID = panelSet.previous_hook_id;
 
         //get the hook id
         return await publish(image1, image2, image3, hooks, parentHookID);

--- a/src/api/apiCalls.ts
+++ b/src/api/apiCalls.ts
@@ -469,14 +469,14 @@ const publishHandler = async(panelSet : CreatePanelSet) =>{
         })
 
         //get the hookId
-        const parentHookID = panelSet.previous_hook_id;
+        const parentHookId = panelSet.previous_hook_id;
 
         //get the hook id
-        return await publish(image1, image2, image3, hooks, parentHookID);
+        return await publish(image1, image2, image3, hooks, parentHookId);
 }
-const publish = async (image1 : File, image2 : File, image3 : File, hooks : Array<hook>, hookId : number | undefined) => {
+const publish = async (image1 : File, image2 : File, image3 : File, hooks : Array<hook>, parentHookId : number | undefined) => {
     const data = {
-        hook_id: hookId,
+        hook_id: parentHookId,
         hooks: hooks
     };
     const formData = new FormData();

--- a/src/app/comic/create/page.tsx
+++ b/src/app/comic/create/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import styles from "@/styles/create.module.css";
-
 import dynamic from 'next/dynamic';
 
 const CreateToolsCanvasPaperJS = dynamic(
@@ -22,10 +21,18 @@ const exportToPNG = () => {
     downloadLink.click();
 }
 
-const Create = () => {
+const Create = ({
+    params,
+    searchParams,
+  }: {
+    params: { id: number }
+    searchParams: { [key: string]: number | undefined }
+  }) => {
+    //redirect if link is incorrect
+    const { id } = searchParams;
     return (
         <main className={`${styles.body}`}>
-            <CreateToolsCanvasPaperJS />
+            <CreateToolsCanvasPaperJS id={Number(id)} />
         </main>
     );
 }

--- a/src/app/comic/create/publish/page.tsx
+++ b/src/app/comic/create/publish/page.tsx
@@ -7,7 +7,15 @@ import styles from "@/styles/publish.module.css";
 
 import backIcon from "../../../../../public/images/back-button-pressed.png"
 
-const Publish = () => {
+const Publish = ({
+    params,
+    searchParams,
+  }: {
+    params: { id: number }
+    searchParams: { [key: string]: number | undefined }
+  }) => {
+    const id = {searchParams}
+    console.log(id + "ID");
     return (<>
         <Navbar />
         <a  href="/comic/create">
@@ -15,7 +23,7 @@ const Publish = () => {
                 <Image src={backIcon} alt="" className={`${styles.buttonIcon}`} width="60" height="60"></Image>
             </button>
         </a>
-        <BranchPage />
+        <BranchPage id = {Number(id)}/>
     </>);
 }
 

--- a/src/app/comic/create/publish/page.tsx
+++ b/src/app/comic/create/publish/page.tsx
@@ -14,11 +14,10 @@ const Publish = ({
     params: { id: number }
     searchParams: { [key: string]: number | undefined }
   }) => {
-    const id = {searchParams}
-    console.log(id + "ID");
+    const {id} = searchParams;
     return (<>
         <Navbar />
-        <a  href="/comic/create">
+        <a  href={`/comic/create?id=${id}`}>
             <button id={`${styles.backButton}`}>
                 <Image src={backIcon} alt="" className={`${styles.buttonIcon}`} width="60" height="60"></Image>
             </button>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -16,10 +16,10 @@ interface Props {
 export default function Card({ topString, bottomString, staticPhoto, hoverPhoto, year, link }: Props) {
   return (
       <div className={`${bottomString?.toLowerCase()} ${styles.personPanel} personPanel card border border-black border-3 m-2 ${year}`} key={topString}>
-        <Image width={300} height={300} src={staticPhoto} className={`${styles.portrait} img-fluid card-img w-100 h-100 rounded-0`} alt="Creator Photos" />
+        <Image width={300} height={300} src={staticPhoto} className={`${styles.portrait} img-fluid card-img w-100 h-100 rounded-0`} alt="Creator Photos" unoptimized = {true} />
         <Link href={`${link}`}>
           <div className="card-img-overlay">
-            <Image width={300} height={300} src={hoverPhoto} className={`${styles.portrait} ${styles.overlayImg} overlay-img img-fluid card-img w-100 h-100 rounded-0`} alt="Creator Drawings" />
+            <Image width={300} height={300} src={hoverPhoto} className={`${styles.portrait} ${styles.overlayImg} overlay-img img-fluid card-img w-100 h-100 rounded-0`} alt="Creator Drawings" unoptimized = {true}/>
             <div className={`${styles.nameText} nameText card-header p-2 rounded-0`}>
               {topString}
             </div>

--- a/src/components/ComicPanels.tsx
+++ b/src/components/ComicPanels.tsx
@@ -45,11 +45,12 @@ const ComicPanels = ({ setting, hook_state, panels, router }: Props) => {
 
     async function hookLink(hook: Hook | CreateHook) {
         if (hook.next_panel_set_id) {
-            router.push(`/comic?id=${hook.next_panel_set_id}`);
+            return router.push(`/comic?id=${hook.next_panel_set_id}`);
         }
         const cookie = await getSessionCookie();
-        if(!cookie || cookie instanceof Error) router.push(`/sign-in`);
-        else router.push(`/comic/create`);
+        if(!cookie || cookie instanceof Error) return router.push(`/sign-in`);
+
+        else return router.push(`/comic/create?id=${(hook as Hook).id}`);
     }
     if (!panels || panels.length === 0) return <div id={`${styles.comicPanels}`} className={`${setting}`}></div>;
 

--- a/src/components/interfaces.tsx
+++ b/src/components/interfaces.tsx
@@ -3,7 +3,7 @@ interface CreatePanel {
     id: number,
     index: number,
     imgSrc: string,
-    previous_hook?: Hook | undefined,
+    previous_hook_id?: number | undefined,
     hooks: CreateHook[]
 }
 
@@ -11,7 +11,7 @@ interface CreatePanelSet{
     id: number,
     author_id: string,
     panels: CreatePanel[],
-    previous_hook?: Hook | undefined;
+    previous_hook_id?: number | undefined;
 }
 
 const emptyPanelSet = () => [

--- a/src/components/publish/BranchPage.tsx
+++ b/src/components/publish/BranchPage.tsx
@@ -6,15 +6,22 @@ import Panel from './Panel';
 import BranchPageControls from './BranchPageControls';
 import { publishHandler } from '../../api/apiCalls';
 import { useRouter } from 'next/navigation';
+import { getHookByID } from '../../api/apiCalls';
 
-const BranchPage = () => {
+interface Props {
+ id : number;
+}
+const BranchPage = ({ id }: Props) => {
     const [addingHook, setAddingHook] = useState(false);
+    const [parentHookId, setParentHookId] = useState<number>();
     const [confirmHook, setConfirmHook] = useState<number>();
     const [selectedHook, setSelectedHook] = useState<{ panelIndex: number, hookIndex: number }>();
     const [panelSet, setPanelSet] = useState<CreatePanelSet>({
         id: 0,
         author_id: '',
-        panels: emptyPanelSet()
+        panels: emptyPanelSet(),
+        previous_hook_id: parentHookId
+
     });
     const [activePanel, setActivePanel] = useState(0);
     const activePanelHooks = () => panelSet.panels[activePanel].hooks;
@@ -59,6 +66,22 @@ const BranchPage = () => {
         //     console.log(user);
         //     if(user.message) router.push(`/sign-in`);
         // });
+
+        //check the id and reroute if needed
+        //route if the link contains an id already created - get the hook by id and check its next
+        getHookByID(id).then((hook) => {
+            if ((hook instanceof Error)) return router.push(`/comic/browse`);
+
+            console.log(id);
+            hook = hook as CreateHook;
+
+            if (!hook.next_panel_set_id) {
+                setParentHookId(id);
+                return;
+            }
+            //use the next id to reroute to read
+            router.push(`/comic/?id=${hook.next_panel_set_id}`);
+        });
         
         // retrieve comic images from create page using local storage
         const storedImageLinks = [

--- a/src/components/publish/BranchPage.tsx
+++ b/src/components/publish/BranchPage.tsx
@@ -20,8 +20,6 @@ const BranchPage = ({ id }: Props) => {
         id: 0,
         author_id: '',
         panels: emptyPanelSet(),
-        previous_hook_id: parentHookId
-
     });
     const [activePanel, setActivePanel] = useState(0);
     const activePanelHooks = () => panelSet.panels[activePanel].hooks;
@@ -193,6 +191,7 @@ const BranchPage = ({ id }: Props) => {
                     confirmBranchHook={() => confirmBranchHook(activePanel)}
                     removeBranchHook={removeBranchHook}
                     publish={async () => {
+                        panelSet.previous_hook_id = parentHookId;
                         const response = await publishHandler(panelSet);
                         console.log(response);
 


### PR DESCRIPTION
# Description
Added id additions to the router links to the create and publish page. This means if a hook is not attached to anything it will go to create with its id as part of the link. 
read>create>publish>read
Publish now publishes as a child of the hook it came off of.

- create page takes in an id parameter and validates in useEffect
- createPage passes id to the publish page
- publish page does takes in id parameter and validates in useEffect
- publish passes that id to api call
- fixed an image bug on the browse page

## Known Issues
Create page doesn't validate user sign in


