### PR TITLE
Updating baseURL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
-*/.env
+.env
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+*/.env
 
 # vercel
 .vercel

--- a/example.env
+++ b/example.env
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "bootstrap": "^5.3.3",
+        "dotenv": "^16.4.5",
         "next": "^14.2.4",
         "paper": "^0.12.17",
         "paperjs-offset": "^1.0.8",
@@ -1546,6 +1547,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "bootstrap": "^5.3.3",
+    "dotenv": "^16.4.5",
     "next": "^14.2.4",
     "paper": "^0.12.17",
     "paperjs-offset": "^1.0.8",

--- a/src/api/apiCalls.ts
+++ b/src/api/apiCalls.ts
@@ -1,6 +1,10 @@
-const baseUrl = 'http://localhost:4000';
 import { CreatePanelSet } from "../components/interfaces";
 import { getSessionCookie } from "@/app/login/loginUtils";
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const baseUrl = process.env.NODE_ENV === 'production' ? 'https://crowd-comic-back-end-6417ec5ea59c.herokuapp.com' : 'http://localhost:4000';
 
 const getAPICall = async (url: string) => {
     return await fetch(`${baseUrl}${url}`, {


### PR DESCRIPTION
Adding a baseURL check so the back-end repo works on the front-end heroku.

By default, the baseURL will be set to `localhost:4000` for development purposes, but will switch to https://crowd-comic-back-end-6417ec5ea59c.herokuapp.com/ once on heroku.

Ensure you have made a `.env` with the code from `example.env`, in the base directory.

_Wait for sequelize migrations before merging._