### PR TITLE
Use New PanelSet Endpoint Return

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -5,7 +5,6 @@ import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { getTrunks, getUserBySession } from '@/api/apiCalls';
 import { logout, getSessionCookie } from '@/app/login/loginUtils';
-import { useRouter } from 'next/navigation';
 
 const NavBar = () => {
     const [isSignedIn, setIsSignedIn] = useState(false);
@@ -29,8 +28,6 @@ const NavBar = () => {
 
         checkUserSession();
     }, []);
-
-    const router = useRouter();
 
     const getTrunkUrl = async () => {
         const trunks = await getTrunks();
@@ -108,8 +105,7 @@ const NavBar = () => {
                                     href=""
                                     onClick={async (e) => {
                                         e.preventDefault();
-                                        const url = await getTrunkUrl();
-                                        router.push(url);
+                                        window.location.href = '/comic';
                                     }}
                                 >
                                   Browse Comics

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -37,7 +37,6 @@ const NavBar = () => {
         if (!trunks) return '/';
         const psID = trunks[0]?.id;
         if (!psID) return '/';
-        console.log(`url: ${psID}`);
         return `/comic?id=${psID}`;
     };
 

--- a/src/components/ReadPage.tsx
+++ b/src/components/ReadPage.tsx
@@ -34,6 +34,15 @@ const ReadPage = ({ id }: Props) => {
     useEffect(() => {
         async function fetchData() {
             setIsLoading(true);
+            console.log(id);
+            if(id==0 || isNaN(id)){
+                const trunks = await apiCalls.getTrunks();
+                if(!updateError(trunks)) {
+                    const trunk = trunks[0];
+                    await router.push(`/comic?id=${trunk.id}`)
+                    return;
+                }
+            }
             const panelSetResponse = await apiCalls.getPanelSetByID(id) as PanelSet;
             // return;
             if (!updateError(panelSetResponse)) {

--- a/src/components/ReadPage.tsx
+++ b/src/components/ReadPage.tsx
@@ -34,19 +34,10 @@ const ReadPage = ({ id }: Props) => {
     useEffect(() => {
         async function fetchData() {
             setIsLoading(true);
-            console.log(id);
-            if(id==0 || isNaN(id)){
-                const trunks = await apiCalls.getTrunks();
-                if(!updateError(trunks)) {
-                    const trunk = trunks[0];
-                    await router.push(`/comic?id=${trunk.id}`)
-                    return;
-                }
-            }
             const panelSetResponse = await apiCalls.getPanelSetByID(id) as PanelSet;
             // return;
             if (!updateError(panelSetResponse)) {
-                const imageUrlsResponse = await apiCalls.getAllImageUrlsByPanelSetId(id);
+                const imageUrlsResponse = await apiCalls.getAllImageUrlsByPanelSetId(panelSetResponse.id);
                 const hookResponses = await apiCalls.getHooksFromPanelSetById(panelSetResponse.id) as Hook[];
 
                 if (!updateError(imageUrlsResponse) && !updateError(hookResponses)) {

--- a/src/components/ReadPage.tsx
+++ b/src/components/ReadPage.tsx
@@ -35,7 +35,6 @@ const ReadPage = ({ id }: Props) => {
         async function fetchData() {
             setIsLoading(true);
             const panelSetResponse = await apiCalls.getPanelSetByID(id) as PanelSet;
-            // return;
             if (!updateError(panelSetResponse)) {
                 const imageUrlsResponse = await apiCalls.getAllImageUrlsByPanelSetId(panelSetResponse.id);
                 const hookResponses = await apiCalls.getHooksFromPanelSetById(panelSetResponse.id) as Hook[];


### PR DESCRIPTION
### Changes
- `NavBar` refactoring
  - "Browse Comics" button now redirects to `/comic` instead of `/comic?id=trunkId` since `getPanelSetByID` will go to the trunk with the `/comic` url.
  - "Browse Comics" button now uses `window.location.href` to redirect as this forces a full page refresh that is necessary when `router.push()` did not
- `ReadPage` refactoring
  - The `getAllImageUrlsByPanelSetId` call now uses the `panelSetResponse` ID instead of the ID  from the arguments in case the argument ID was NaN

_This PR needs to be tested with back end PR [52](https://github.com/RIT-Crowd-Comic/crowd-comic-back-end/pull/52)_