### PR TITLE
Bugfix: Create and Publish Back Buttons

### DIFF
--- a/src/app/comic/create/publish/page.tsx
+++ b/src/app/comic/create/publish/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Navbar from '../../../../components/NavBar';
 import BranchPage from '../../../../components/publish/BranchPage';
 import styles from '@/styles/publish.module.css';
+import Link from 'next/link';
 
 import backIcon from '../../../../../public/images/back-button-pressed.png';
 
@@ -17,11 +18,11 @@ const Publish = ({
     const {id} = searchParams;
     return (<>
         <Navbar />
-        <a  href={`/comic/create?id=${id}`}>
+        <Link  href={`/comic/create?id=${id}`} replace={true}>
             <button id={`${styles.backButton}`}>
                 <Image src={backIcon} alt="" className={`${styles.buttonIcon}`} width="60" height="60"></Image>
             </button>
-        </a>
+        </Link>
         <BranchPage id = {Number(id)}/>
         <h1></h1>
     </>);

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -1284,7 +1284,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         localStorage.setItem("image-1", String(canvasProject.current?.exportSVG({ asString: true })));
 
         // Send the user to the publish page
-        router.push(`/comic/create/publish?id=${parentHookId}`);
+        router.replace(`/comic/create/publish?id=${parentHookId}`);
     }
 
     const infoDisplay = (visible: boolean) => {


### PR DESCRIPTION
### Issue
From the publish page, there is no way to get back to the comic read page that the user initially started on. Hitting the back button on the publish page will return the user to the corresponding create page but then the back button on the create page will return the player to the publish page. This creates a loop the prevent the user from return to the panel set they left from. 

### Fix
Linking from the create to the publish page is done without pushing the publish page on the history stack so when the create page's Back button is clicked, the page returned to is the panel set it initially came from.