### PR TITLE
3 Panel Exporting (Round 3)

### DIFF
--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -1279,11 +1279,15 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
             {
                 // Import the layer's data to the layer below it
                 // NOTE: exportSVG must be used instead of exportJSON as importJSON will overwrite any preexisting changes to the layer, importSVG adds to the layer
-                let mergeData = String(layers[currentLayerIndex]?.current.exportSVG({asString: true}));
-                layers[currentLayerIndex - 1].current?.importSVG(mergeData);
+                let toSVG = layers[currentLayerIndex]?.current.exportSVG({asString: true});
+                if(toSVG)
+                {
+                    let mergeData = String(toSVG);
+                    layers[currentLayerIndex - 1].current?.importSVG(mergeData);
 
-                // Clear the layer's data
-                layers[currentLayerIndex].current.removeChildren();
+                    // Clear the layer's data
+                    layers[currentLayerIndex].current.removeChildren();
+                }
             }
         }
     }

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -1603,7 +1603,6 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
             
         }
         console.log(divs)
-        
     }
 
     // Return the canvas HTMLElement and its associated functionality   1

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -1268,12 +1268,49 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
             if(layers[currentLayerIndex].current && layers[currentLayerIndex - 1].current)
             {
                 // Import the layer's data to the layer below it
+                // NOTE: exportSVG must be used instead of exportJSON as importJSON will overwrite any preexisting changes to the layer, importSVG adds to the layer
                 let mergeData = String(layers[currentLayerIndex].current.exportSVG({asString: true}));
                 layers[currentLayerIndex - 1].current?.importSVG(mergeData);
 
                 // Clear the layer's data
                 layers[currentLayerIndex].current.removeChildren();
             }
+        }
+    }
+
+    // Helper Function for the layer moving functions
+    // Swaps layer data between two layers
+    const swapLayers = (currentIndex: number, swapIndex: number) => {
+        // First make sure that the layer indicies exist
+        if(currentIndex >= 0 && swapIndex >= 0)
+        {
+            const currentData = String(layers[currentIndex].current?.exportJSON({ asString: true}));
+            const swapData = String(layers[swapIndex].current?.exportJSON({ asString: true}));
+            layers[currentIndex].current?.importJSON(swapData);
+            layers[swapIndex].current?.importJSON(currentData);
+        }
+    }
+
+    const moveLayerUp = () => {
+        // First make sure that there is a layer above the current selected one to move to
+        if(currentLayerIndex < layers.length - 1)
+        {
+            // Swap layer data between the two layers
+            swapLayers(currentLayerIndex, currentLayerIndex + 1);
+
+            // Swap layer titles between the two
+
+        }
+    }
+
+    const moveLayerDown = () => {
+        // First make sure that there is a layer below the current selected one to move to
+        if(currentLayerIndex > 0)
+        {
+            // Swap layer data between the two layers
+            swapLayers(currentLayerIndex, currentLayerIndex - 1);
+
+            // Swap layer titles between the two
         }
     }
 
@@ -1617,12 +1654,12 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
                         </div>
                         <div id="layerUpSetting" className={styles.layerStyling}>
                             <label htmlFor="layerup" id={styles.layerUpLabel} className={`${styles.sizeConsistency}`}>
-                                <input type="button" className={`${styles.sizeConsistency}`} title="Move Layer Up" id="layerup" />
+                                <input type="button" className={`${styles.sizeConsistency}`} title="Move Layer Up" id="layerup" onClick={moveLayerUp}/>
                             </label>
                         </div>
                         <div id="layerDownSetting" className={styles.layerStyling}>
                             <label htmlFor="layerdown" id={styles.layerDownLabel} className={`${styles.sizeConsistency}`}>
-                                <button type="button" className={`${styles.sizeConsistency}`} title="Move Layer Down" id="layerdown" />
+                                <button type="button" className={`${styles.sizeConsistency}`} title="Move Layer Down" id="layerdown" onClick={moveLayerDown}/>
                             </label>
                         </div>
                     </div>

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -301,8 +301,6 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         clipPath.strokeColor = new paper.Color('pink');
         clipPath.strokeWidth = shadeSize;
         clipPath.strokeCap = 'round';
-
-
     }
 
     //continues drawing preview path
@@ -1478,37 +1476,58 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         save(false);
 
         // Create a temp dummy layer to add layer data to publish
-        let publishLayer = new paper.Layer();
+        //let publishLayer = new paper.Layer();
 
         // Export Panel 1
-        publishLayer.importJSON(panel1LayerData.background);
+        /*publishLayer.importJSON(panel1LayerData.background);
         publishLayer.importJSON(panel1LayerData.shade);
         publishLayer.importJSON(panel1LayerData.layer1);
         publishLayer.importJSON(panel1LayerData.layer2);
         publishLayer.importJSON(panel1LayerData.layer3);
         publishLayer.importJSON(panel1LayerData.layer4);
         localStorage.setItem("image-1", String(publishLayer.exportSVG({ asString: true })));
-        publishLayer.removeChildren();
+        publishLayer.removeChildren();*/
+        backgroundLayerReference.current?.importJSON(panel1LayerData.background);
+        shadingLayerRef.current?.importJSON(panel1LayerData.shade);
+        layer1Reference.current?.importJSON(panel1LayerData.layer1);
+        layer2Reference.current?.importJSON(panel1LayerData.layer2);
+        layer3Reference.current?.importJSON(panel1LayerData.layer3);
+        layer4Reference.current?.importJSON(panel1LayerData.layer4);
+        localStorage.setItem("image-1", String(canvasProject.current?.exportSVG({ asString: true })));
 
         // Export Panel 2
-        publishLayer.importJSON(panel2LayerData.background);
+        /*publishLayer.importJSON(panel2LayerData.background);
         publishLayer.importJSON(panel2LayerData.shade);
         publishLayer.importJSON(panel2LayerData.layer1);
         publishLayer.importJSON(panel2LayerData.layer2);
         publishLayer.importJSON(panel2LayerData.layer3);
         publishLayer.importJSON(panel2LayerData.layer4);
         localStorage.setItem("image-2", String(publishLayer.exportSVG({ asString: true })));
-        publishLayer.removeChildren();
+        publishLayer.removeChildren();*/
+        backgroundLayerReference.current?.importJSON(panel2LayerData.background);
+        shadingLayerRef.current?.importJSON(panel2LayerData.shade);
+        layer1Reference.current?.importJSON(panel2LayerData.layer1);
+        layer2Reference.current?.importJSON(panel2LayerData.layer2);
+        layer3Reference.current?.importJSON(panel2LayerData.layer3);
+        layer4Reference.current?.importJSON(panel2LayerData.layer4);
+        localStorage.setItem("image-2", String(canvasProject.current?.exportSVG({ asString: true })));
 
         // Export Panel 3
-        publishLayer.importJSON(panel3LayerData.background);
+        /*publishLayer.importJSON(panel3LayerData.background);
         publishLayer.importJSON(panel3LayerData.shade);
         publishLayer.importJSON(panel3LayerData.layer1);
         publishLayer.importJSON(panel3LayerData.layer2);
         publishLayer.importJSON(panel3LayerData.layer3);
         publishLayer.importJSON(panel3LayerData.layer4);
         localStorage.setItem("image-3", String(publishLayer.exportSVG({ asString: true })));
-        publishLayer.removeChildren();
+        publishLayer.removeChildren();*/
+        backgroundLayerReference.current?.importJSON(panel3LayerData.background);
+        shadingLayerRef.current?.importJSON(panel3LayerData.shade);
+        layer1Reference.current?.importJSON(panel3LayerData.layer1);
+        layer2Reference.current?.importJSON(panel3LayerData.layer2);
+        layer3Reference.current?.importJSON(panel3LayerData.layer3);
+        layer4Reference.current?.importJSON(panel3LayerData.layer4);
+        localStorage.setItem("image-3", String(canvasProject.current?.exportSVG({ asString: true })));
 
         // Save the SVG Image to localStorage
         //localStorage.setItem("image-1", String(canvasProject.current?.exportSVG({ asString: true })));

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -153,11 +153,9 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         setPanel3LayerData(defaultLayerData);
 
         // If previous layer data exists, set the layers to that, otherwise make new layers
+        // Panel 1
         try {
             let panel1JsonData = localStorage.getItem("panel-1-layerData");
-            let panel2JsonData = localStorage.getItem("panel-2-layerData");
-            let panel3JsonData = localStorage.getItem("panel-3-layerData");
-
             if(panel1JsonData)
             {
                 // Set panel1's layer data from storage
@@ -174,23 +172,37 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
                 layer3Reference.current.importJSON(layerData.layer3);
                 layer4Reference.current.importJSON(layerData.layer4);
             }
+        }
+        catch(error) {
+            alert("Error loading panel 1 data from localStorage: " + error);
+        }
 
+        // Panel 2
+        try {
+            let panel2JsonData = localStorage.getItem("panel-2-layerData");
             if(panel2JsonData)
             {
                 let layerData = JSON.parse(panel2JsonData);
                 setPanel2LayerData(layerData);
             }
+        }
+        catch(error)
+        {
+            alert("Error loading panel 2 data from localStorage: " + error);
+        }
 
+        // Panel 3
+        try {
+            let panel3JsonData = localStorage.getItem("panel-3-layerData");
             if(panel3JsonData)
             {
                 let layerData = JSON.parse(panel3JsonData);
                 setPanel3LayerData(layerData);
             }
-
         }
-        catch(error) {
-
-            console.log(error);
+        catch(error)
+        {
+            alert("Error loading panel 3 data from localStorage: " + error);
         }
 
         const context = canvas.getContext("2d");
@@ -1309,6 +1321,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
             swapLayers(currentLayerIndex, currentLayerIndex - 1);
 
             // Swap layer titles between the two
+
         }
     }
 
@@ -1460,9 +1473,32 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         updateCurrentPanel();
 
         // Save the layerData object to localStorage in JSON string form
-        localStorage.setItem("panel-1-layerData", JSON.stringify(panel1LayerData));
-        localStorage.setItem("panel-2-layerData", JSON.stringify(panel2LayerData));
-        localStorage.setItem("panel-3-layerData", JSON.stringify(panel3LayerData));
+        // Panel 1
+        try{
+            localStorage.setItem("panel-1-layerData", JSON.stringify(panel1LayerData));
+        }
+        catch(error)
+        {
+            alert("Error saving panel 1's layer data to localStorage: " + error);
+        }
+        
+        // Panel 2
+        try{
+            localStorage.setItem("panel-2-layerData", JSON.stringify(panel2LayerData));
+        }
+        catch(error)
+        {
+            alert("Error saving panel 2's layer data to localStorage: " + error);
+        }
+
+        // Panel 1
+        try{
+            localStorage.setItem("panel-3-layerData", JSON.stringify(panel3LayerData));
+        }
+        catch(error)
+        {
+            alert("Error saving panel 3's layer data to localStorage: " + error);
+        }
 
         // Alert the user that their progress has been saved
         if (showAlert) {
@@ -1493,7 +1529,12 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         layer2Reference.current?.importJSON(panel1LayerData.layer2);
         layer3Reference.current?.importJSON(panel1LayerData.layer3);
         layer4Reference.current?.importJSON(panel1LayerData.layer4);
-        localStorage.setItem("image-1", String(canvasProject.current?.exportSVG({ asString: true })));
+        try{
+            localStorage.setItem("image-1", String(canvasProject.current?.exportSVG({ asString: true })));
+        }
+        catch(error){
+            alert("Error publishing panel 1 to localStorage: " + error);
+        }
 
         // Export Panel 2
         /*publishLayer.importJSON(panel2LayerData.background);
@@ -1510,7 +1551,12 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         layer2Reference.current?.importJSON(panel2LayerData.layer2);
         layer3Reference.current?.importJSON(panel2LayerData.layer3);
         layer4Reference.current?.importJSON(panel2LayerData.layer4);
-        localStorage.setItem("image-2", String(canvasProject.current?.exportSVG({ asString: true })));
+        try{
+            localStorage.setItem("image-2", String(canvasProject.current?.exportSVG({ asString: true })));
+        }
+        catch(error){
+            alert("Error publishing panel 2 to localStorage: " + error);
+        }
 
         // Export Panel 3
         /*publishLayer.importJSON(panel3LayerData.background);
@@ -1527,7 +1573,12 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         layer2Reference.current?.importJSON(panel3LayerData.layer2);
         layer3Reference.current?.importJSON(panel3LayerData.layer3);
         layer4Reference.current?.importJSON(panel3LayerData.layer4);
-        localStorage.setItem("image-3", String(canvasProject.current?.exportSVG({ asString: true })));
+        try{
+            localStorage.setItem("image-3", String(canvasProject.current?.exportSVG({ asString: true })));
+        }
+        catch(error){
+            alert("Error publishing panel 3 to localStorage: " + error);
+        }
 
         // Save the SVG Image to localStorage
         //localStorage.setItem("image-1", String(canvasProject.current?.exportSVG({ asString: true })));

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -1279,7 +1279,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
             {
                 // Import the layer's data to the layer below it
                 // NOTE: exportSVG must be used instead of exportJSON as importJSON will overwrite any preexisting changes to the layer, importSVG adds to the layer
-                let mergeData = String(layers[currentLayerIndex].current.exportSVG({asString: true}));
+                let mergeData = String(layers[currentLayerIndex]?.current.exportSVG({asString: true}));
                 layers[currentLayerIndex - 1].current?.importSVG(mergeData);
 
                 // Clear the layer's data

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -633,7 +633,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
     const [textFont, setTextFont] = useState<string>("Arial");
 
     // Integer that determines the size of the text 
-    const [textSize, setTextSize] = useState<number>(30);
+    const [textSize, setTextSize] = useState<number>(12);
 
     // String that determines the font weight of the text being printed to the layer
     // !!! Can only be "normal", "bold", or "italic"
@@ -1275,18 +1275,18 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         // Check to make sure that this is not being called on the bottom layer (backgroundLayer) that has nowhere to merge down to 
         if(currentLayerIndex > 0)
         {
-            if(layers[currentLayerIndex].current && layers[currentLayerIndex - 1].current)
+            if(layers[currentLayerIndex]?.current && layers[currentLayerIndex - 1].current)
             {
                 // Import the layer's data to the layer below it
                 // NOTE: exportSVG must be used instead of exportJSON as importJSON will overwrite any preexisting changes to the layer, importSVG adds to the layer
-                let toSVG = layers[currentLayerIndex]?.current.exportSVG({asString: true});
+                let toSVG = layers[currentLayerIndex]?.current?.exportSVG({asString: true});
                 if(toSVG)
                 {
                     let mergeData = String(toSVG);
-                    layers[currentLayerIndex - 1].current?.importSVG(mergeData);
-
+                    layers[currentLayerIndex - 1]?.current?.importSVG(mergeData);
+                    
                     // Clear the layer's data
-                    layers[currentLayerIndex].current.removeChildren();
+                    layers[currentLayerIndex]?.current?.removeChildren();
                 }
             }
         }

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -75,6 +75,9 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
     let layer3Reference = useRef<paper.Layer>();
     let layer4Reference = useRef<paper.Layer>();
 
+    const layers = [backgroundLayerReference, layer1Reference, layer2Reference, layer3Reference, layer4Reference];
+    const [currentLayerIndex, setCurrentLayerIndex] = useState<Number>(1);
+
     // Router for sending the user to other pages (used in toPublish())
     const router = useRouter();
 
@@ -122,6 +125,12 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         // Set the layer references
         // Set the layer references as well as the default active layer
         backgroundLayerReference.current = canvasProject.current.activeLayer;
+        
+        // Add a white background the size of the canvas by default
+        //let backgroundPath = new paper.Path.Rectangle(new paper.Point(0, 0), new paper.Point(canvas.width, canvas.height));
+        //backgroundPath.fillColor = new paper.Color(new paper.Color("white"));
+        //backgroundPath.strokeColor = new paper.Color(new paper.Color("white"));
+
         shadingLayerRef.current = new paper.Layer();
         layer1Reference.current = new paper.Layer();
         layer2Reference.current = new paper.Layer();
@@ -156,6 +165,8 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
                 setPanel1LayerData(layerData);
 
                 // Need to show panel 1 on screen as it is the 1st panel you see in the editor
+                // Get rid of the background applied earlier
+                //backgroundLayerReference.current.removeChildren();
                 backgroundLayerReference.current.importJSON(layerData.background);
                 shadingLayerRef.current.importJSON(layerData.shade);
                 layer1Reference.current.importJSON(layerData.layer1);
@@ -1205,21 +1216,27 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         switch (Number(layerSelected.value)) {
             case 0:
                 backgroundLayerReference.current?.activate();
+                setCurrentLayerIndex(0);
                 break;
             case 1:
                 layer1Reference.current?.activate();
+                setCurrentLayerIndex(1);
                 break;
             case 2:
                 layer2Reference.current?.activate();
+                setCurrentLayerIndex(2);
                 break;
             case 3:
                 layer3Reference.current?.activate();
+                setCurrentLayerIndex(3);
                 break;
             case 4:
                 layer4Reference.current?.activate();
+                setCurrentLayerIndex(4);
                 break;
             default:
                 layer1Reference.current?.activate();
+                setCurrentLayerIndex(1);
                 break;
         }
     }
@@ -1491,7 +1508,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
 
                     <div id={styles.shaderTool} className={styles.toolStyling}>
                         <label htmlFor="shader" className={`${styles.sizeConsistency}`} id={styles.shaderLabel}>
-                            <input type="radio" name="tools" id="shader" title="Shading/Pattern Tool" value={toolStates.SHADER} className={`${styles.sizeConsistency}`} onChange={findSelectedTool} />
+                            <input type="radio" name="tools" id="shader" title="Pattern Tool" value={toolStates.SHADER} className={`${styles.sizeConsistency}`} onChange={findSelectedTool} />
                         </label>
                     </div>
 
@@ -1537,7 +1554,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
                     </label>
 
                     <label htmlFor="clearButton" className={`${styles.sizeConsistency}`} id={styles.clearLabel}>
-                        <button className={`btn ${styles.sizeConsistency}`} id="clearButton" title="Clear" onClick={clearLayer}></button>
+                        <button className={`btn ${styles.sizeConsistency}`} id="clearButton" title="Clear Layer" onClick={clearLayer}></button>
                     </label>
                 </div>
 
@@ -1545,7 +1562,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
                     <form id={styles.backgroundUpload}>
                         <label htmlFor="imageDropbox" className={`form-label ${styles.formLabel} ${styles.sizeConsistency}`}>{/* Upload a Background (Recommended Size: 1200x800p) */}
                             <input
-                                 className={`form-control ${styles.sizeConsistency}`}
+                                className={`form-control ${styles.sizeConsistency}`}
                                 id="imageDropbox"
                                 type="file"
                                 accept="image/*"
@@ -1579,17 +1596,17 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
                     <div id="settings" className={styles.layerSettings}>
                         <div id="mergeSetting" className={styles.layerStyling}>
                             <label htmlFor="merge" id={styles.mergeLabel} className={`${styles.sizeConsistency}`}>
-                                <input type="button" className={`${styles.sizeConsistency}`} title="Merge Down" id="merge" />
+                                <input type="button" className={`${styles.sizeConsistency}`} title="Merge Layer Down" id="merge" />
+                            </label>
+                        </div>
+                        <div id="layerUpSetting" className={styles.layerStyling}>
+                            <label htmlFor="layerup" id={styles.layerUpLabel} className={`${styles.sizeConsistency}`}>
+                                <input type="button" className={`${styles.sizeConsistency}`} title="Move Layer Up" id="layerup" />
                             </label>
                         </div>
                         <div id="layerDownSetting" className={styles.layerStyling}>
                             <label htmlFor="layerdown" id={styles.layerDownLabel} className={`${styles.sizeConsistency}`}>
                                 <button type="button" className={`${styles.sizeConsistency}`} title="Move Layer Down" id="layerdown" />
-                            </label>
-                        </div>
-                        <div id="layerUpSetting" className={styles.layerStyling}>
-                            <label htmlFor="layerup" id={styles.layerUpLabel} className={`${styles.sizeConsistency}`}>
-                                <input type="button" className={`${styles.sizeConsistency}`} title="TMove Layer Up" id="layerup" />
                             </label>
                         </div>
                     </div>
@@ -1683,19 +1700,19 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
             <div id="panelSelect" className={styles.panelSelect}>
                     <div id="panel1" className={styles.panelStyling}>
                         <label htmlFor="panel1Select" className={styles.panelLabel}>
-                            <input type="radio" name="panels" className={`${styles.sizeConsistency}`} id="panel1Select" value={0} defaultChecked onChange={findSelectedPanel}/>
+                            <input type="radio" name="panels" className={`${styles.sizeConsistency}`} id="panel1Select" value={0} title="Panel 1" defaultChecked onChange={findSelectedPanel}/>
                         </label>
                     </div>
 
                     <div id="panel2" className={styles.panelStyling}>
                         <label htmlFor="panel2Select" className={styles.panelLabel}>
-                            <input type="radio" name="panels" className={`${styles.sizeConsistency}`} id="panel2Select" value={1} onChange={findSelectedPanel}/>
+                            <input type="radio" name="panels" className={`${styles.sizeConsistency}`} id="panel2Select" value={1} title="Panel 2" onChange={findSelectedPanel}/>
                         </label>
                     </div>
 
                     <div id="panel3" className={styles.panelStyling}>
                         <label htmlFor="panel3Select" className={styles.panelLabel}>
-                            <input type="radio" name="panels" className={`${styles.sizeConsistency}`} id="panel3Select" value={2} onChange={findSelectedPanel}/>
+                            <input type="radio" name="panels" className={`${styles.sizeConsistency}`} id="panel3Select" value={2} title="Panel 3" onChange={findSelectedPanel}/>
                         </label>
                     </div>
                 </div>

--- a/src/components/CreateToolsCanvasPaperJS.tsx
+++ b/src/components/CreateToolsCanvasPaperJS.tsx
@@ -76,7 +76,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
     let layer4Reference = useRef<paper.Layer>();
 
     const layers = [backgroundLayerReference, layer1Reference, layer2Reference, layer3Reference, layer4Reference];
-    const [currentLayerIndex, setCurrentLayerIndex] = useState<Number>(1);
+    const [currentLayerIndex, setCurrentLayerIndex] = useState<number>(1);
 
     // Router for sending the user to other pages (used in toPublish())
     const router = useRouter();
@@ -1260,6 +1260,22 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
         }
     }
     
+    // If the selected layer isn't the last layer in the hierarchy, merge it a layer down
+    const mergeLayer = () => {
+        // Check to make sure that this is not being called on the bottom layer (backgroundLayer) that has nowhere to merge down to 
+        if(currentLayerIndex > 0)
+        {
+            if(layers[currentLayerIndex].current && layers[currentLayerIndex - 1].current)
+            {
+                // Import the layer's data to the layer below it
+                let mergeData = String(layers[currentLayerIndex].current.exportSVG({asString: true}));
+                layers[currentLayerIndex - 1].current?.importSVG(mergeData);
+
+                // Clear the layer's data
+                layers[currentLayerIndex].current.removeChildren();
+            }
+        }
+    }
 
     const toggleLayerVisibility = (event: ChangeEvent<HTMLInputElement>) => {
         if (backgroundLayerReference.current && event.target.value === '0') {
@@ -1596,7 +1612,7 @@ const CreateToolsCanvasPaperJS = ({ id }: Props) => {
                     <div id="settings" className={styles.layerSettings}>
                         <div id="mergeSetting" className={styles.layerStyling}>
                             <label htmlFor="merge" id={styles.mergeLabel} className={`${styles.sizeConsistency}`}>
-                                <input type="button" className={`${styles.sizeConsistency}`} title="Merge Layer Down" id="merge" />
+                                <input type="button" className={`${styles.sizeConsistency}`} title="Merge Layer Down" id="merge" onClick={mergeLayer}/>
                             </label>
                         </div>
                         <div id="layerUpSetting" className={styles.layerStyling}>

--- a/src/components/publish/BranchPage.tsx
+++ b/src/components/publish/BranchPage.tsx
@@ -226,6 +226,15 @@ const BranchPage = ({ id }: Props) => {
                         }
                         else {
                             const queryString = new URLSearchParams({ id: response.panel_set }).toString();
+                            
+                            // Clear localStorage so that the user can create new panels in the future
+                            localStorage.setItem("panel-1-layerData", "");
+                            localStorage.setItem("panel-2-layerData", "");
+                            localStorage.setItem("panel-3-layerData", "");
+                            localStorage.setItem("image-1", "");
+                            localStorage.setItem("image-2", "");
+                            localStorage.setItem("image-3", "");
+                            
                             router.push(`/comic/?${queryString}`);
                         }
 


### PR DESCRIPTION
3 Panel Exporting
- Uses previous method of exporting the project after setting layer data to each panel's specific layer data
- Still exports as an SVG, perfectly responsive on my setup on both Publish and Reading pages

Layer Functions
- Added Layer moving (both up and down) in the layer hierarchy
- Added Layer merging down

Misc.
- Updated onHover title tags for tools
- Added more in depth try/catch protections around all localStorage calls that will alert the user when an error occurs