### PR TITLE
Remove Password Usage from User Objects

### DIFF
--- a/src/api/apiCalls.ts
+++ b/src/api/apiCalls.ts
@@ -279,10 +279,9 @@ const getAllImageUrlsByPanelSetId = async (id: number) => {
 }
 
 
-const changeDisplayName = async (email: string, password: string, newDisplayName: string) => {
+const changeDisplayName = async (email: string, newDisplayName: string) => {
     const response = await postAPICall(`/changeDisplayName`, {
         email: email,
-        password: password,
         newDisplayName: newDisplayName
     })
 

--- a/src/app/login/loginUtils.ts
+++ b/src/app/login/loginUtils.ts
@@ -95,7 +95,7 @@ const updateDisplayName = async (newName: string) => {
     if(!session || session instanceof Error) return session;
     const user = await getUserBySession(session.value);
     if(!user || user instanceof Error) return user;
-    return await changeDisplayName(user.email, user.password, newName);
+    return await changeDisplayName(user.email, newName);
 };
 
 const updatePassword = async (oldPassword: string, newPassword: string, passwordConfirm: string) => {


### PR DESCRIPTION
`ChangeDisplayName` no longer requires a password since it no longer can get a password from the `getUserBySession` API call. It is impossible for the user to change their display name without being logged in to the dashboard.

_Should be tested with back-end PR [62](https://github.com/RIT-Crowd-Comic/crowd-comic-back-end/pull/62)_