### PR TITLE
Src in ProfilePicture Fixed

### DIFF
--- a/src/components/ProfilePicture.tsx
+++ b/src/components/ProfilePicture.tsx
@@ -15,12 +15,12 @@ export default function ProfilePicture({ pfp, width, height } : Props) {
     return (
         <Image
             id={styles.profileIcon}
-            className=""
             src={pfp ? pfp : '/images/icons/Profile.svg'}
             width={width}
             height={height}
             style={{ borderRadius: 100 }}
             alt="Profile Picture"
+            unoptimized={true}
         />
     );
 }


### PR DESCRIPTION
Changed the `src` of the `Image` in `ProfilePicture` to be unoptimized. "unoptimized" being true is the only difference between the `Image` in `Signature` (which works on Heroku) and the `Image` in `ProfilePicture`. 

**Signature on Heroku**
<img src = 'https://github.com/user-attachments/assets/778fa2fd-1a1f-426d-ae12-e0e7a8512001' width=500 height=275>

**ProfilePicture on Heroku**
<img src='https://github.com/user-attachments/assets/6d313763-76a8-45d9-8d13-8a84915900f1' width=500 height=250>

As long as the `ProfilePicture` `img` uses the basic source format like `Signature`, it should work on Heroku
